### PR TITLE
Fix typo in URL/domain name/broken link.

### DIFF
--- a/blog/getting-started-with-go-2015-01-28.markdown
+++ b/blog/getting-started-with-go-2015-01-28.markdown
@@ -72,7 +72,7 @@ Testing
 -------
 
 To test the go compilers with a simple 
-[todo command](http://github,com/mattn/todo), run this:
+[todo command](http://github.com/mattn/todo), run this:
 
 ```console
 $ go get github.com/mattn/todo


### PR DESCRIPTION
Trivial fix.
